### PR TITLE
feat(workbench): Add file metadata above spectrogram

### DIFF
--- a/frontend/src/AudioAnnotator/AudioAnnotator.js
+++ b/frontend/src/AudioAnnotator/AudioAnnotator.js
@@ -30,6 +30,12 @@ export type SpectroUrlsParams = {
   urls: Array<string>,
 };
 
+export type FileMetadata = {
+  name: string,
+  date: Date,
+  audioRate: number,
+};
+
 export type RawAnnotation = {
   id: string,
   annotation: string,
@@ -61,6 +67,7 @@ type AnnotationTask = {
     startFrequency: number,
     endFrequency: number,
   },
+  audioRate: number,
   audioUrl: string,
   spectroUrls: Array<SpectroUrlsParams>,
   prevAnnotations: Array<RawAnnotation>,
@@ -497,6 +504,13 @@ class AudioAnnotator extends Component<AudioAnnotatorProps, AudioAnnotatorState>
         );
       }
 
+      // File data
+      const fileMetadata: FileMetadata = {
+        name: task.audioUrl.split('/').pop(),
+        date: new Date(task.boundaries.startTime),
+        audioRate: task.audioRate,
+      };
+
       // Displayable annotations (for presence mode)
       const boxAnnotations = this.state.annotations.filter((ann: Annotation) => ann.type === TYPE_BOX);
 
@@ -544,6 +558,7 @@ class AudioAnnotator extends Component<AudioAnnotatorProps, AudioAnnotatorState>
             tagColors={this.state.tagColors}
             currentTime={this.state.currentTime}
             duration={this.state.duration}
+            fileMetadata={fileMetadata}
             startFrequency={task.boundaries.startFrequency}
             frequencyRange={this.state.frequencyRange}
             spectroUrlsParams={task.spectroUrls}

--- a/frontend/src/AudioAnnotator/Workbench.js
+++ b/frontend/src/AudioAnnotator/Workbench.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import * as utils from '../utils';
 
-import type { Annotation, SpectroUrlsParams } from './AudioAnnotator';
+import type { Annotation, FileMetadata, SpectroUrlsParams } from './AudioAnnotator';
 import { TYPE_BOX } from './AudioAnnotator';
 import Region from './Region';
 
@@ -43,6 +43,7 @@ type WorkbenchProps = {
   tagColors: Map<string, string>,
   currentTime: number,
   duration: number,
+  fileMetadata: FileMetadata,
   startFrequency: number,
   frequencyRange: number,
   spectroUrlsParams: Array<SpectroUrlsParams>,
@@ -648,6 +649,11 @@ class Workbench extends Component<WorkbenchProps, WorkbenchState> {
           <button className="btn-simple fa fa-search-plus" onClick={() => this.zoom(1)}></button>
           <button className="btn-simple fa fa-search-minus" onClick={() => this.zoom(-1)}></button>
           <span>{this.state.currentZoom}x</span>
+        </p>
+
+        <p className="workbench-info">
+          File : <strong>{this.props.fileMetadata.name}</strong> - Sampling : <strong>{this.props.fileMetadata.audioRate} Hz</strong><br />
+          Start date : <strong>{this.props.fileMetadata.date.toUTCString()}</strong>
         </p>
 
         <canvas

--- a/frontend/src/css/annotator.css
+++ b/frontend/src/css/annotator.css
@@ -110,6 +110,16 @@ html {
   padding: 5px;
 }
 
+.workbench-info {
+  position: absolute;
+  top: 10px;
+  right: 100px;
+  background-color: #ffffff;
+  border-radius: 5px;
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
 .canvas-wrapper {
   position: absolute;
   right: 0;


### PR DESCRIPTION
Display file metadata (name, start date and sampling frequency) above spectrogram.
See task #10 