### PR TITLE
feat(campaign export): add is_box column for annotation scopes

### DIFF
--- a/backend/api/views/annotation_campaign.py
+++ b/backend/api/views/annotation_campaign.py
@@ -83,12 +83,12 @@ class AnnotationCampaignViewSet(viewsets.ViewSet):
             OpenApiExample(
                 "CSV campaign results example",
                 # pylint: disable-next=line-too-long
-                value="""dataset,filename,start_time,end_time,start_frequency,end_frequency,annotation,annotator,start_datetime,end_datetime
-SPM Aural A,sound000.wav,418.0,572.0,9370.0,11567.0,Boat,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00
-SPM Aural A,sound000.wav,543.0,663.0,6333.0,9119.0,Rain,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00
-SPM Aural A,sound001.wav,30.0,233.0,549.0,3551.0,Odoncetes,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00
-SPM Aural A,sound001.wav,1.0,151.0,5751.0,9341.0,Rain,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00
-SPM Aural B,sound000.wav,284.0,493.0,5794.0,8359.0,Boat,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00""",
+                value="""dataset,filename,start_time,end_time,start_frequency,end_frequency,annotation,annotator,start_datetime,end_datetime,is_box
+SPM Aural A,sound000.wav,418.0,572.0,9370.0,11567.0,Boat,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00,1
+SPM Aural A,sound000.wav,543.0,663.0,6333.0,9119.0,Rain,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00,1
+SPM Aural A,sound001.wav,30.0,233.0,549.0,3551.0,Odoncetes,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00,1
+SPM Aural A,sound001.wav,1.0,151.0,5751.0,9341.0,Rain,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00,1
+SPM Aural B,sound000.wav,284.0,493.0,5794.0,8359.0,Boat,Albert,2012-05-03T11:10:03+00:00,2012-05-03T11:10:48+00:00,1""",
                 media_type="text/csv",
             )
         ],

--- a/backend/api/views/annotation_campaign.py
+++ b/backend/api/views/annotation_campaign.py
@@ -109,6 +109,7 @@ SPM Aural B,sound000.wav,284.0,493.0,5794.0,8359.0,Boat,Albert,2012-05-03T11:10:
                 "annotator",
                 "start_datetime",
                 "end_datetime",
+                "is_box",
             ]
         ]
         results = AnnotationResult.objects.prefetch_related(
@@ -140,6 +141,10 @@ SPM Aural B,sound000.wav,284.0,493.0,5794.0,8359.0,Boat,Albert,2012-05-03T11:10:
                         audio_meta.start
                         + timedelta(seconds=(result.end_time or max_time))
                     ).isoformat(timespec="milliseconds"),
+                    "1"
+                    if campaign.annotation_scope
+                    == AnnotationCampaign.AnnotationScope.RECTANGLE
+                    else "0",
                 ]
             )
         response = Response(data)

--- a/backend/tests/views/annotation_campaign.py
+++ b/backend/tests/views/annotation_campaign.py
@@ -225,6 +225,7 @@ class AnnotationCampaignViewSetTestCase(APITestCase):
                 "annotator",
                 "start_datetime",
                 "end_datetime",
+                "is_box",
             ],
         )
         self.assertEqual(
@@ -240,6 +241,7 @@ class AnnotationCampaignViewSetTestCase(APITestCase):
                 "user2",
                 "2012-10-03T16:01:59.635+00:00",
                 "2012-10-03T16:04:38.488+00:00",
+                "1",
             ],
         )
 


### PR DESCRIPTION
Add an `is_box` column to match the annotation mode for the campaign:

- `1` for boxes
- `0` for presence / absence mode

See task #11 